### PR TITLE
fix lastlogin always now()

### DIFF
--- a/Components/DbServices/Import/CustomerImporter.php
+++ b/Components/DbServices/Import/CustomerImporter.php
@@ -405,7 +405,7 @@ class CustomerImporter
             (string)$customer['customergroup']
         );
         $customer['firstlogin'] = empty($customer['firstlogin']) ? $this->db->quote((string)date('Y-m-d')) : $this->toDate($customer['firstlogin']);
-        $customer['lastlogin'] = empty($article['lastlogin']) ? $this->db->quote((string)date('Y-m-d H:i:s')) : $this->toTimeStamp($customer['lastlogin']);
+        $customer['lastlogin'] = empty($customer['lastlogin']) ? $this->db->quote((string)date('Y-m-d H:i:s')) : $this->toTimeStamp($customer['lastlogin']);
 
         return $customer;
     }


### PR DESCRIPTION
When `lastlogin` is migrated `$articles` is used to check for empty
values instead of `$customer`.
Without this fix `lastlogin` of migrated customers will always be `now()`.