### PR TITLE
Avoid error in case of missing config key

### DIFF
--- a/Components/Migration/Profile/Oxid.php
+++ b/Components/Migration/Profile/Oxid.php
@@ -84,8 +84,12 @@ class Oxid extends Profile
     {
         $keys = [];
         $params = $this->Config()->aLanguageParams;
-        foreach ($params as $id => $param) {
-            $keys[$param['baseId']] = $id;
+        if (empty($params)) {
+            $keys = array_keys($this->getLanguages());
+        } else {
+            foreach ($params as $id => $param) {
+                $keys[$param['baseId']] = $id;
+            }
         }
 
         return $keys;


### PR DESCRIPTION
This patch avoids an error raised in case the config key `aLanguageParams` is not available and uses original code found in oxid esales.