### PR TITLE
Fix logfile path

### DIFF
--- a/Components/Migration/Profiler.php
+++ b/Components/Migration/Profiler.php
@@ -49,7 +49,7 @@ class Profiler extends \Zend_Db_Profiler
 
         parent::__construct($enabled);
 
-        $migrationPath = Shopware()->Container()->getParameter('shopware.app.rootdir') . 'files/migration';
+        $migrationPath = Shopware()->Container()->getParameter('shopware.app.rootdir') . 'files/migration/';
         if (!is_dir($migrationPath)) {
             mkdir($migrationPath);
         }


### PR DESCRIPTION
The missing `/` results in the creation of log files named `migration2018-06-16 21:34.log.txt` etc. inside the `files` directory instead of log files labeled only with the timestamp inside `files/migration`.

Btw: the path mentioned in the documentation is completely wrong: https://community.shopware.com/_detail_1011_797.html#Debug-Modus