### PR TITLE
Allow customer specific password salts

### DIFF
--- a/Components/Migration/Import/Resource/Customer.php
+++ b/Components/Migration/Import/Resource/Customer.php
@@ -79,6 +79,10 @@ class Customer extends AbstractResource
 
         if ($call['profile'] !== 'WooCommerce') {
             while ($customer = $result->fetch()) {
+                if (!empty($customer['salt'])) {
+                    // use customer specific salt
+                    $salt = $customer['salt'];
+                }
                 $this->migrateCustomer($customer, $import, $salt);
             }
         } elseif ($call['profile'] === 'WooCommerce') {


### PR DESCRIPTION
This change allows customer specific password salts wich are stored inside the database (e.g. customers table).