### PR TITLE
Clean up article translations

### DIFF
--- a/Components/Migration/Cleanup.php
+++ b/Components/Migration/Cleanup.php
@@ -150,7 +150,7 @@ class Cleanup
      */
     public function sDeleteAllArticles()
     {
-        $sql = '
+        $sql = <<<SQL
             SET foreign_key_checks = 0;
 			TRUNCATE s_articles;
 			TRUNCATE s_filter_articles;
@@ -173,6 +173,7 @@ class Cleanup
 			TRUNCATE s_articles_relationships;
 			TRUNCATE s_articles_similar;
 			TRUNCATE s_articles_translations;
+			DELETE FROM s_core_translations WHERE objecttype = 'article'; 
 			TRUNCATE s_article_configurator_dependencies;
 			TRUNCATE s_article_configurator_groups;
 			TRUNCATE s_article_configurator_options;
@@ -187,7 +188,7 @@ class Cleanup
 			TRUNCATE s_article_configurator_templates;
 			TRUNCATE s_article_img_mapping_rules;
 			TRUNCATE s_article_img_mappings;
-        ';
+SQL;
 
         Shopware()->Db()->query($sql);
 


### PR DESCRIPTION
`s_article_translations` get cleaned up but not `s_core_translations`. This is easy to spot if you import data into an installation where demo data where previously imported.

1. Import demo data
2. Clean up with SwagMigration
3. Import via API or SwagMigration
4. Open product in English shop
5. See old product data if recent imported product got the same primary key as from a product in the demo data