### PR TITLE
Added clean data command

### DIFF
--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -6,6 +6,7 @@
  * file that was distributed with this source code.
  */
 use Doctrine\DBAL\Connection;
+use Doctrine\Common\Collections\ArrayCollection;
 use Enlight_Components_Db_Adapter_Pdo_Mysql as PDOConnection;
 use Shopware\SwagMigration\Components\Migration\PasswordEncoder\Md5Reversed;
 use Shopware\SwagMigration\Components\Migration\PasswordEncoder\Sha512;
@@ -205,6 +206,9 @@ class Shopware_Plugins_Backend_SwagMigration_Bootstrap extends Shopware_Componen
         $this->subscribeEvent('Shopware_Components_Password_Manager_AddEncoder', 'onAddPasswordEncoder');
 
         $this->subscribeEvent('Enlight_Controller_Action_PostDispatch', 'onPostDispatch', 110);
+
+        $this->subscribeEvent('Shopware_Console_Add_Command', 'onStartDispatch');
+        $this->subscribeEvent('Shopware_Console_Add_Command', 'onAddConsoleCommands');
     }
 
     /**
@@ -283,6 +287,18 @@ class Shopware_Plugins_Backend_SwagMigration_Bootstrap extends Shopware_Componen
         $hashes[] = new Sha512();
 
         return $hashes;
+    }
+
+    /**
+     * Callback function to register commands
+     *
+     * @return ArrayCollection
+     */
+    public function onAddConsoleCommands()
+    {
+        return new ArrayCollection([
+            new \Shopware\SwagMigration\Commands\CleanDataCommand(),
+        ]);
     }
 
     /**

--- a/Commands/CleanDataCommand.php
+++ b/Commands/CleanDataCommand.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Shopware\SwagMigration\Commands;
+
+use Shopware\Commands\ShopwareCommand;
+use Shopware\SwagMigration\Components\Migration\Cleanup;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class CleanDataCommand extends ShopwareCommand
+{
+    /**
+     * List of all possible data categories.
+     */
+    const DATA_CATEGORIES = [
+        'clear_customers',
+        'clear_orders',
+        'clear_votes',
+        'clear_articles',
+        'clear_categories',
+        'clear_supplier',
+        'clear_properties',
+        'clear_mappings',
+        'clear_images',
+        'clear_article_downloads',
+        'clear_esd_article_downloads',
+    ];
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('sw:migration:clean:data')
+            ->setDescription('Clears all data by selected categories')
+            ->addArgument(
+                'categories',
+                InputArgument::IS_ARRAY,
+                'Categories of data to be cleared'
+            )
+            ->addOption(
+                'all',
+                'a',
+                InputOption::VALUE_NONE,
+                'Use this to clear all data'
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        if ($input->getOption('all')) {
+            $categories = self::DATA_CATEGORIES;
+        } else {
+            $inputCategories = $input->getArgument('categories');
+            $categories = array_intersect($inputCategories, self::DATA_CATEGORIES);
+            if (empty($categories)) {
+                throw new RuntimeException('Not enough arguments (missing: "categories")');
+            }
+        }
+
+        $cleanup = new Cleanup();
+        $cleanup->cleanUpByArray(array_fill_keys($categories, true));
+
+        $io->success(sprintf('Data categories(%s) where successfully cleared.', implode(', ', $categories)));
+    }
+}


### PR DESCRIPTION
Added command to clear data via command line. I am using this plugin often to clean up my setups where I migrate data into the shop. As I primarily work from the command line the cleanup is the only time I use the administration. This pull request shall fix the lack of a cleanup command.

I am willing to add a completion feature if https://github.com/shopware/shopware/pull/1488 is merged.