### PR TITLE
Removed unused key in for-each

### DIFF
--- a/Components/Migration/Cleanup.php
+++ b/Components/Migration/Cleanup.php
@@ -54,7 +54,7 @@ class Cleanup
         /* @var DeleteService $deleteService */
         $deleteService = Shopware()->Container()->get('swagmigration.deleteService');
 
-        foreach ($data as $key => $value) {
+        foreach ($data as $key) {
             switch ($key) {
                 case 'clear_customers':
                     $this->sDeleteAllCustomers();

--- a/Controllers/Backend/SwagMigration.php
+++ b/Controllers/Backend/SwagMigration.php
@@ -250,7 +250,7 @@ class Shopware_Controllers_Backend_SwagMigration extends Shopware_Controllers_Ba
         $data = $this->Request()->getParams();
 
         $cleanup = new Cleanup();
-        $cleanup->cleanUpByArray($data);
+        $cleanup->cleanUpByArray(array_keys($data));
 
         echo Zend_Json::encode(['success' => true]);
     }


### PR DESCRIPTION
It is a bad style to pipe request data directly into a business logic layer. Therefore one should not check input names in logic layer.

This is a breaking change which will break https://github.com/shopwareLabs/SwagMigration/pull/31. If this gets merged I can fix this too.