### PR TITLE
Fixed clearFolder method of Cleanup component

### DIFF
--- a/Components/Migration/Cleanup.php
+++ b/Components/Migration/Cleanup.php
@@ -329,8 +329,14 @@ class Cleanup
      */
     private function clearFolder($path, $type = null)
     {
+        $path .= DIRECTORY_SEPARATOR;
+
         if ($handle = opendir($path)) {
             while (false !== ($file = readdir($handle))) {
+                if (!is_file($file)) {
+                    continue;
+                }
+
                 switch ($type) {
                     case 'image':
                         // only delete .jpg, .jpeg, .png and .gif; ignore case

--- a/Components/Migration/Cleanup.php
+++ b/Components/Migration/Cleanup.php
@@ -317,7 +317,7 @@ class Cleanup
         // delete files
         $filesDir = $this->shopBasePath . 'files';
         $this->clearFolder(
-            $filesDir . $this->shopConfig->get('sESDKEY')
+            $filesDir . DIRECTORY_SEPARATOR . $this->shopConfig->get('sESDKEY')
         );
     }
 
@@ -331,7 +331,7 @@ class Cleanup
     {
         $path .= DIRECTORY_SEPARATOR;
 
-        if ($handle = opendir($path)) {
+        if (is_dir($path) && $handle = opendir($path)) {
             while (false !== ($file = readdir($handle))) {
                 if (!is_file($file)) {
                     continue;


### PR DESCRIPTION
Added slash between $path and $file. Also skipped directories as unlink does not work on these.