### PR TITLE
Fixed Error 'Integrity constraint violation: 1052 Column 'id_product'…

### DIFF
--- a/Components/Migration/Profile/Prestashop14.php
+++ b/Components/Migration/Profile/Prestashop14.php
@@ -284,7 +284,7 @@ class Prestashop14 extends Profile
 					ON a.id_product=pr.id_product
 
 					WHERE `id_group`=$price_group || `id_group`=0
-					ORDER BY id_product, `from`
+					ORDER BY pr.id_product, `from`
 				";
             }
         }

--- a/Components/Migration/Profile/Prestashop15.php
+++ b/Components/Migration/Profile/Prestashop15.php
@@ -292,7 +292,7 @@ class Prestashop15 extends Profile
 					ON a.id_product=pr.id_product
 
 					WHERE `id_group`=$price_group || `id_group`=0
-					ORDER BY id_product, `from`
+					ORDER BY pr.id_product, `from`
 				";
             }
         }


### PR DESCRIPTION
… in order clause is ambiguous' when importing from Prestashop

See Forums Thread: https://forum.shopware.com/discussion/34668/migrationstool-importfehler-prestashop-shopware

It did the trick for me and at the moment I can't see any problems possible with this small change