### PR TITLE
Bugs bei Attribute und Bilder Import behoben.  "61 Joins" bei Magento für Attribute gefixt  

### DIFF
--- a/Components/DbServices/Import/ImageImporter.php
+++ b/Components/DbServices/Import/ImageImporter.php
@@ -203,7 +203,7 @@ class ImageImporter
      */
     private function copyImage($image, $name)
     {
-        $uploadDir = Shopware()->Container()->getParameter('shopware.app.rootdir') . 'media/temp';
+        $uploadDir = Shopware()->Container()->getParameter('shopware.app.rootdir') . 'media/temp/';
 
         $ext = '';
         if (!empty($image)) {
@@ -215,6 +215,7 @@ class ImageImporter
             }
 
             $uploadFile = $uploadDir . $name . $ext;
+
             if (!copy($image, $uploadFile)) {
                 $this->logger->error("Copying image from '$image' to '$uploadFile' did not work!");
 

--- a/Components/Migration/Import/Resource/Image.php
+++ b/Components/Migration/Import/Resource/Image.php
@@ -71,7 +71,10 @@ class Image extends AbstractResource
         $this->initTaskTimer();
 
         if ($call['profile'] !== 'WooCommerce') {
-            $image_path = rtrim($this->Request()->basepath, '/') . '/' . $this->Source()->getProductImagePath();
+            $productImagePath = '/' . $this->Source()->getProductImagePath();
+            $productImagePath = str_replace('//', '/', $productImagePath);
+
+            $image_path = rtrim($this->Request()->basepath, '/') . $productImagePath;
         }
 
         /* @var Import $import */

--- a/Components/Migration/Import/Resource/Product.php
+++ b/Components/Migration/Import/Resource/Product.php
@@ -228,8 +228,12 @@ class Product extends AbstractResource
         if (!empty($attributes)) {
             foreach ($attributes as $source => $target) {
                 if (!empty($target) && isset($product[$source])) {
+                    if ($source == 'ean') {
                     $product[$target] = $product[$source];
+                    } else {
+                    $product['attr'][$target] = $product[$source];
                     unset($product[$source]);
+                    }
                 }
             }
         }

--- a/Components/Migration/Profile/Magento.php
+++ b/Components/Migration/Profile/Magento.php
@@ -334,11 +334,10 @@ class Magento extends Profile
             'special_price',
         ];
 
-        $custom_select = '';
+        $productAttributes = array();
+
         foreach ($this->getAttributes() as $attributeID => $attribute) {
-            $custom_select .= ",
-				$attributeID.value									as `$attributeID`";
-            $attributes[] = $attributeID;
+            $productAttributes[] = $attributeID;
         }
 
         $sql = "
@@ -365,7 +364,8 @@ class Magento extends Profile
 				IFNULL(special_price.value, price.value)		as price,
 				IF(special_price.value IS NULL, 0, price.value) as pseudoprice
 
-				$custom_select
+                {$this->createAttributeSelect('catalog_product', $productAttributes, 0)}
+                
 
 			FROM {$this->quoteTable('catalog_product_entity')} catalog_product
 
@@ -814,5 +814,65 @@ class Magento extends Profile
 				FROM {$this->quoteTable($type . '_entity')} $type
 				$join_fields
 			";
+    }
+
+
+    /**
+     * Returns the sql statement to select the shop system article attribute fields
+     *
+     * @param string $type
+     * @param null   $attributes
+     * @param null   $store_id
+     *
+     * @return string
+     */
+    public function createAttributeSelect(
+        $type = 'catalog_product',
+        $attributes = null,
+        $store_id = null
+    ) {
+        $sql = "
+			SELECT
+				ea.attribute_code 	as `name`,
+				ea.attribute_id 	as `id`,
+				ea.backend_type 	as `type`,
+				ea.is_required		as `required`
+			FROM {$this->quoteTable('eav_attribute')} ea, {$this->quoteTable('eav_entity_type')} et
+			WHERE ea.`entity_type_id`=et.entity_type_id
+			AND et.entity_type_code=?
+			AND ea.frontend_input!=''
+		";
+        if (!empty($attributes)) {
+            $sql .= 'AND ea.attribute_code IN (' . $this->Db()->quote($attributes) . ')';
+        } else {
+            $sql .= 'ORDER BY `required` DESC, `name`';
+        }
+        $attribute_fields = $this->Db()->fetchAssoc($sql, [$type]);
+
+        if (empty($attributes)) {
+            $attributes = array_keys($attribute_fields);
+        }
+
+        $join_fields = '';
+        foreach ($attributes as $attribute) {
+            if (empty($attribute_fields[$attribute])) {
+                $join_fields .= ",
+					NULL as `$attribute`
+				";
+            } else {
+                $join_fields .="
+                ,(
+                    SELECT value FROM {$this->quoteTable($type . '_entity_' . $attribute_fields[$attribute]['type'])} 
+                    WHERE entity_id = {$type}.entity_id 
+                    AND store_id = {$this->Db()->quote($store_id)} 
+                    AND attribute_id = {$attribute_fields[$attribute]['id']}
+                ) as `{$attribute}`
+                ";
+            }
+        }
+
+//        $join_fields = implode(', ', $join_fields);
+
+        return $join_fields;
     }
 }


### PR DESCRIPTION
- fixed image import (tested with magento import), also added a fallback to prevent doubled slash on the path
- fixed attribute import (tested with magento import), excluded ean so that the import works normally
- changed import behaviour for attributes with the magento profile. From multiple joins to selects to prevent "General error: 1116 Too many tables; MySQL can only use 61 tables in a join"

Cody <3