### PR TITLE
Support magento attribute import to custom shopware attributes

### DIFF
--- a/Components/Migration/Import/Resource/Product.php
+++ b/Components/Migration/Import/Resource/Product.php
@@ -226,7 +226,7 @@ class Product extends AbstractResource
 
         //Attribute
         if (!empty($attributes)) {
-            if (array_key_exists('attr', $product) {
+            if (!array_key_exists('attr', $product)) {
                 $product['attr'] = [];
             }
 

--- a/Components/Migration/Import/Resource/Product.php
+++ b/Components/Migration/Import/Resource/Product.php
@@ -226,9 +226,14 @@ class Product extends AbstractResource
 
         //Attribute
         if (!empty($attributes)) {
+            if (array_key_exists('attr', $product) {
+                $product['attr'] = [];
+            }
+
             foreach ($attributes as $source => $target) {
                 if (!empty($target) && isset($product[$source])) {
                     $product[$target] = $product[$source];
+                    $product['attr'][$target] = $product[$source];
                     unset($product[$source]);
                 }
             }


### PR DESCRIPTION
The attribute mapping seems just to support the ~~legacy~~ history driven attributes attr1 to attr20. This fix adds support for all custom attributes. If you choose an attribute that is not in attr1 to attr20 the attribute is not getting filled.