### PR TITLE
Add missing directory separator to upload path

### DIFF
--- a/Components/DbServices/Import/ImageImporter.php
+++ b/Components/DbServices/Import/ImageImporter.php
@@ -203,7 +203,7 @@ class ImageImporter
      */
     private function copyImage($image, $name)
     {
-        $uploadDir = Shopware()->Container()->getParameter('shopware.app.rootdir') . 'media/temp';
+        $uploadDir = Shopware()->Container()->getParameter('shopware.app.rootdir') . 'media/temp/';
 
         $ext = '';
         if (!empty($image)) {


### PR DESCRIPTION
without the changes, all imported image names will be prepended with `temp` and placed directly into the `media` directory.

<img width="660" alt="article images" src="https://user-images.githubusercontent.com/35578471/58379708-9d7d2080-7fa7-11e9-8007-c6a8f0959e86.png">

<img width="192" alt="media directory" src="https://user-images.githubusercontent.com/35578471/58379716-bbe31c00-7fa7-11e9-9d01-5ef57cf7b0b9.png">
